### PR TITLE
Use sha256 instead of sha1

### DIFF
--- a/Formula/colorart.rb
+++ b/Formula/colorart.rb
@@ -7,7 +7,7 @@ class Colorart < Formula
     version '0.2.0'
 
     url 'http://release.delatech.net.s3-website-eu-west-1.amazonaws.com/colorart/colorart-0.2.0.tar.gz'
-    sha1 'f38606477977c39d9f7a6af01e651389c37334fb'
+    sha256 '24f22e0d0e2564027ec2dd61c35b53c9e5729c4eeab425dfe86437dd7464f74e'
 
     depends_on :arch => :intel
 

--- a/Formula/ctags-better-php.rb
+++ b/Formula/ctags-better-php.rb
@@ -3,7 +3,7 @@ require 'formula'
 class CtagsBetterPhp < Formula
   homepage 'http://ctags.sourceforge.net/'
   url 'https://github.com/shawncplus/phpcomplete.vim/raw/master/misc/ctags-5.8_better_php_parser.tar.gz'
-  sha1 '24167d881f6c5827b96564d64c14ec9ee1b2273c'
+  sha256 'eb21430e13f41ab7f1080137c365a60ff4bbddc4361017e674d67f195f79cbdf'
 
   def install
     system "./configure", "--prefix=#{prefix}",

--- a/Formula/htail.rb
+++ b/Formula/htail.rb
@@ -7,7 +7,7 @@ class Htail < Formula
     version '0.0.8'
 
     url 'http://release.delatech.net.s3-website-eu-west-1.amazonaws.com/htail/htail-0.0.8.tar.gz'
-    sha1 'b8f4ba598a435b6d28def31d3c5a9a94b2e3e37c'
+    sha256 'd43882d53e6a6517710179588d175567aa4cd2852131f4bfaf768f16d10a72e4'
 
     depends_on :arch => :intel
 

--- a/Formula/waveform.rb
+++ b/Formula/waveform.rb
@@ -7,7 +7,7 @@ class Waveform < Formula
     version '0.3.2'
 
     url 'http://release.delatech.net.s3-website-eu-west-1.amazonaws.com/waveform/waveform-0.3.2.tar.gz'
-    sha1 '0c70e87cfe207288ac9e702409819eebae2e6e7c'
+    sha256 'e1ee3e05497033d5840cec292c2a88d31cef2ea75efc769cd67e5d9fd6935e14'
 
     depends_on :arch => :intel
 


### PR DESCRIPTION
Replace `sha1` function by `sha256`. `sha1` is now deprecated.

```
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/delatech/homebrew-delatech/Formula/htail.rb:10:in `<class:Htail>'
Please report this to the delatech/delatech tap!

Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Library/Taps/delatech/homebrew-delatech/Formula/htail.rb:10:in `<class:Htail>'
Please report this to the delatech/delatech tap!

Warning: Calling Resource#sha1 is deprecated!
Use Resource#sha256 instead.
/usr/local/Library/Taps/delatech/homebrew-delatech/Formula/htail.rb:10:in `<class:Htail>'
Please report this to the delatech/delatech tap!
```
